### PR TITLE
fix: enforce module visibility and pointer modules

### DIFF
--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -40,7 +40,7 @@ func (c *GreetingController) RegisterRoutes(r mkhttp.Router) {
 
 type AppModule struct{}
 
-func (m AppModule) Definition() module.ModuleDef {
+func (m *AppModule) Definition() module.ModuleDef {
     return module.ModuleDef{
         Name: "app",
         Providers: []module.ProviderDef{
@@ -68,6 +68,8 @@ func (m AppModule) Definition() module.ModuleDef {
 }
 ```
 
+Modules must be passed as pointers so shared imports have stable identities.
+
 ## Bootstrap and Serve
 
 ```go
@@ -83,7 +85,7 @@ import (
 )
 
 func main() {
-    appInstance, err := kernel.Bootstrap(app.AppModule{})
+    appInstance, err := kernel.Bootstrap(&app.AppModule{})
     if err != nil {
         log.Fatal(err)
     }

--- a/docs/guides/modules.md
+++ b/docs/guides/modules.md
@@ -16,6 +16,8 @@ A module is any type that implements:
 Definition() module.ModuleDef
 ```
 
+Modules must be passed as pointers (e.g. `&AppModule{}`); value modules are rejected so shared imports have stable identity.
+
 ## Tokens and Providers
 
 Tokens are `module.Token` values that identify providers. Providers are singletons created lazily when requested.

--- a/examples/hello-mysql/internal/modules/app/module.go
+++ b/examples/hello-mysql/internal/modules/app/module.go
@@ -21,10 +21,10 @@ type Module struct {
 type AppModule = Module
 
 func NewModule(opts Options) module.Module {
-	return Module{opts: opts}
+	return &Module{opts: opts}
 }
 
-func (m Module) Definition() module.ModuleDef {
+func (m *Module) Definition() module.ModuleDef {
 	dbModule := database.NewModule(database.Options{DSN: m.opts.MySQLDSN})
 	usersModule := users.NewModule(users.Options{Database: dbModule})
 	auditModule := audit.NewModule(audit.Options{Users: usersModule})

--- a/examples/hello-mysql/internal/modules/audit/module.go
+++ b/examples/hello-mysql/internal/modules/audit/module.go
@@ -16,10 +16,10 @@ type Module struct {
 }
 
 func NewModule(opts Options) module.Module {
-	return Module{opts: opts}
+	return &Module{opts: opts}
 }
 
-func (m Module) Definition() module.ModuleDef {
+func (m *Module) Definition() module.ModuleDef {
 	return module.ModuleDef{
 		Name:    "audit",
 		Imports: []module.Module{m.opts.Users},

--- a/modkit/kernel/bootstrap.go
+++ b/modkit/kernel/bootstrap.go
@@ -4,7 +4,7 @@ import "github.com/aryeko/modkit/modkit/module"
 
 type App struct {
 	Graph       *Graph
-	Container   *Container
+	container   *Container
 	Controllers map[string]any
 }
 
@@ -41,7 +41,17 @@ func Bootstrap(root module.Module) (*App, error) {
 
 	return &App{
 		Graph:       graph,
-		Container:   container,
+		container:   container,
 		Controllers: controllers,
 	}, nil
+}
+
+// Resolver returns a root-scoped resolver that enforces module visibility.
+func (a *App) Resolver() module.Resolver {
+	return a.container.resolverFor(a.Graph.Root)
+}
+
+// Get resolves a token from the root module scope.
+func (a *App) Get(token module.Token) (any, error) {
+	return a.Resolver().Get(token)
 }

--- a/modkit/kernel/errors.go
+++ b/modkit/kernel/errors.go
@@ -20,6 +20,27 @@ func (e *InvalidModuleNameError) Error() string {
 	return fmt.Sprintf("invalid module name: %q", e.Name)
 }
 
+type ModuleNotPointerError struct {
+	Module string
+}
+
+func (e *ModuleNotPointerError) Error() string {
+	return fmt.Sprintf("module must be a pointer: %q", e.Module)
+}
+
+type InvalidModuleDefError struct {
+	Module string
+	Reason string
+}
+
+func (e *InvalidModuleDefError) Error() string {
+	return fmt.Sprintf("invalid module definition: module=%q reason=%s", e.Module, e.Reason)
+}
+
+func (e *InvalidModuleDefError) Unwrap() error {
+	return module.ErrInvalidModuleDef
+}
+
 type NilImportError struct {
 	Module string
 	Index  int


### PR DESCRIPTION
## Summary
- Enforce pointer-only modules, module definition validation, and container access via App resolver.

## Changes
- Hide App container behind Resolver()/Get() and update tests to use the public API.
- Reject non-pointer modules in graph build with a dedicated error.
- Validate module definitions (names, provider/controller fields, exports) and wrap module.ErrInvalidModuleDef.
- Update docs and example modules to use pointer modules.

## Testing
- go test ./modkit/...
- go test ./...

## Notes
- go test ./... ran successfully but only covered modkit packages (cached).
