### PR TITLE
docs: add issue linking guidance

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -39,9 +39,13 @@ make fmt && make lint && make test
 - [ ] Documentation updated (if applicable)
 - [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
 
-## Related Issues
+## Resolves
 
-<!-- Link issues: "Closes #123" or "Relates to #456" -->
+<!-- If implementing a GitHub issue, add "Resolves #<number>" for each issue -->
+<!-- For sub-issues, add separate "Resolves #<sub-issue>" lines -->
+<!-- If work is not tied to an issue, delete this section -->
+
+Resolves #
 
 ## Notes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,11 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for commit format (Conventional Commits) 
 - Valid types: `feat`, `fix`, `docs`, `test`, `chore`, `refactor`, `perf`, `ci`
 - Run `make fmt && make lint && make test` before submitting
 
+**Issue Linking:**
+- When implementing a GitHub issue, include `Resolves #<issue>` in the PR description
+- For sub-issues, add separate `Resolves #<sub-issue>` lines
+- If work is not tied to an issue, omit Resolves lines
+
 ## Documentation
 
 - User guides: `docs/guides/*.md`


### PR DESCRIPTION
## Summary

Add guidance for linking PRs to GitHub issues, aligning with getvim conventions.

## Changes

- Add "Issue Linking" section to `AGENTS.md` explaining `Resolves #<issue>` pattern
- Update PR template: rename "Related Issues" to "Resolves" with clearer instructions
- Add guidance for handling sub-issues

## Test plan

- [x] AGENTS.md updated
- [x] PR template updated


Made with [Cursor](https://cursor.com)