### PR TITLE
docs: add hierarchical AGENTS knowledge bases

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,100 +1,74 @@
-# AI Agent Guidelines
+# PROJECT KNOWLEDGE BASE
 
-This file provides AI-focused instructions for code generation and modifications. For human contributors, see [CONTRIBUTING.md](CONTRIBUTING.md).
+**Generated:** 2026-02-07T10:40:45Z
+**Commit:** 85a5d8b
+**Branch:** chore/init-deep-agents
 
-## Project Identity
+## OVERVIEW
+modkit is a Go framework for modular backend services (NestJS-inspired, Go-idiomatic): explicit boundaries, explicit DI tokens, deterministic bootstrap, no runtime magic.
 
-modkit is a **Go framework for building modular backend services, inspired by NestJS**. It provides:
-- Module system with explicit imports/exports and visibility enforcement
-- No reflection, no decorators, no magic
-- Explicit dependency injection via string tokens
-- Chi-based HTTP adapter
-- Go-idiomatic patterns (explicit errors, standard `http.Handler` middleware)
-
-## Project Structure
-
+## STRUCTURE
 ```text
 modkit/
-├── modkit/              # Core library packages
-│   ├── module/          # Module metadata types
-│   ├── kernel/          # Graph builder, bootstrap
-│   ├── http/            # HTTP adapter (chi-based)
-│   └── logging/         # Logging interface
-├── examples/            # Example applications
-│   ├── hello-simple/    # Minimal example (no dependencies)
-│   └── hello-mysql/     # Full CRUD example with DB
-└── docs/
-    ├── guides/          # User guides
-    ├── reference/       # API reference
-    └── architecture.md  # How modkit works
+|- modkit/                 # Core framework packages
+|  |- module/              # Public module metadata API
+|  |- kernel/              # Graph, visibility, container, bootstrap
+|  |- http/                # Router/server/middleware adapter (chi)
+|  `- logging/             # Logging contract + adapters
+|- examples/               # Separate Go modules using modkit
+|  |- hello-simple/        # Smallest possible end-to-end app
+|  `- hello-mysql/         # Full app: auth/users/db/migrations/sqlc/swagger
+`- docs/                   # Guides, reference, architecture, specs
 ```
 
-## Development Workflow
+## WHERE TO LOOK
+| Task | Location | Notes |
+|---|---|---|
+| Module metadata types | `modkit/module` | `ModuleDef`, `ProviderDef`, tokens, validation |
+| Bootstrap and DI behavior | `modkit/kernel` | Import graph, visibility rules, lazy singleton container |
+| HTTP route registration | `modkit/http` | Controllers register via explicit router contract |
+| Logging interfaces | `modkit/logging` | `slog` adapter + nop logger |
+| Minimal runnable example | `examples/hello-simple/main.go` | Smallest canonical bootstrap flow |
+| Production-like sample app | `examples/hello-mysql` | Separate module, compose, migrations, sqlc, swagger |
+| User docs | `docs/guides` | How-to guidance by topic |
 
-**Before making changes:**
+## CODE MAP
+LSP unavailable here; use `rg` + tests as code-map proxies.
+
+High-signal packages by density:
+- `modkit/kernel` (14 files, mostly behavior tests): graph build, visibility, container lifecycle, typed errors.
+- `modkit/http` (11 files): router/server/middleware/logging integration.
+- `examples/hello-mysql/internal/modules/{auth,users}` (32 files): sample app domain patterns.
+
+## CONVENTIONS
+- Modules are pointers; names are unique; `Definition()` is deterministic.
+- Provider tokens use `"module.component"`; providers are lazy singletons.
+- Resolve dependencies via `r.Get()` and check `err` before type assertion.
+- Controllers implement `RegisterRoutes(router Router)` and use explicit route methods.
+- Error handling is explicit: return/wrap errors, no panic-driven control flow.
+- Keep tests near implementation (`*_test.go`), table-driven where useful.
+
+## ANTI-PATTERNS (THIS PROJECT)
+- Do not introduce reflection/decorator magic in user-facing APIs.
+- Do not make `Definition()` stateful (e.g., counters/mutable side effects).
+- Do not bypass module visibility via cross-module direct wiring.
+- Do not globally exclude tests from lint rules (`.golangci.yml` guards this).
+- Do not hand-edit generated artifacts (`*.sql.go`, swagger-generated docs files).
+
+## UNIQUE STYLES
+- Multi-module workspace (`go.work`) includes root + both examples.
+- Root `make test` iterates every `go.mod` module with `-race`.
+- CI enforces Go `1.25.7` plus lint/vuln/coverage gates.
+- Commit and PR titles follow Conventional Commits.
+
+## COMMANDS
 ```bash
-make fmt    # Format code (gofmt + goimports)
-make lint   # Run golangci-lint (must pass)
-make test   # Run all tests (must pass)
+make fmt
+make lint
+make vuln
+make test
+make test-coverage
 ```
 
-## Code Generation Guidelines
-
-### Modules
-- Modules must be pointers (`&AppModule{}`)
-- `Definition()` must be pure/deterministic
-- Module names must be unique
-- Use constructor functions for modules with configuration
-
-### Providers
-- Token convention: `"module.component"` (e.g., `"users.service"`)
-- Providers are lazy singletons (built on first `Get()`)
-- Always check `err` from `r.Get()`
-- Type assert the resolved value
-
-### Controllers
-- Must implement `RegisterRoutes(router Router)`
-- Use `r.Handle(method, pattern, handler)` for routes
-- Use `r.Group()` and `r.Use()` for scoped middleware
-
-### Error Handling
-- Return errors, don't panic
-- Use sentinel errors for known conditions
-- Wrap errors with context: `fmt.Errorf("context: %w", err)`
-- No global exception handlers (explicit in handlers/middleware)
-
-### Testing
-- Unit tests alongside code (`*_test.go`)
-- Table-driven tests for multiple cases
-- Bootstrap real modules in integration tests
-- Use testcontainers for smoke tests with external deps
-
-## Commits and Pull Requests
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for commit format (Conventional Commits) and PR requirements.
-
-**Quick reference:**
-- Valid types: `feat`, `fix`, `docs`, `test`, `chore`, `refactor`, `perf`, `ci`
-- PR titles must use Conventional Commits format (`type: short summary`)
-- Run `make fmt && make lint && make test` before submitting
-
-**Issue Linking:**
-- When implementing a GitHub issue, include `Resolves #<issue>` in the PR description
-- For sub-issues, add separate `Resolves #<sub-issue>` lines
-- If work is not tied to an issue, omit Resolves lines
-
-## Documentation
-
-- User guides: `docs/guides/*.md`
-- API reference: `docs/reference/api.md`
-- Architecture deep-dive: `docs/architecture.md`
-- Keep examples in sync with docs
-- Use Mermaid for diagrams where helpful
-
-## Principles
-
-- **Explicit over implicit**: No reflection, no magic
-- **Go-idiomatic**: Prefer language patterns over framework abstractions
-- **Minimal API surface**: Export only what users need
-- **Clear errors**: Typed errors with helpful messages
-- **Testability**: Easy to test with standard Go testing
+## NOTES
+- Local guidance: `modkit/AGENTS.md`, `examples/AGENTS.md`, `examples/hello-mysql/AGENTS.md`, `examples/hello-mysql/internal/modules/AGENTS.md`.

--- a/examples/AGENTS.md
+++ b/examples/AGENTS.md
@@ -1,0 +1,38 @@
+# EXAMPLES KNOWLEDGE BASE
+
+## OVERVIEW
+`examples/` contains runnable consuming apps in separate Go modules.
+
+## STRUCTURE
+```text
+examples/
+|- hello-simple/   # Minimal single-file app
+`- hello-mysql/    # Full app with auth/users/db/sqlc/swagger
+```
+
+## WHERE TO LOOK
+| Task | Location | Notes |
+|---|---|---|
+| Minimal usage of modkit bootstrap | `examples/hello-simple/main.go` | Canonical first example |
+| Production-like wiring | `examples/hello-mysql/cmd/api/main.go` | Real server startup/shutdown |
+| Example app workflow | `examples/hello-mysql/Makefile` | Compose/migrate/seed/sqlc/swagger |
+| Example docs and runbook | `examples/hello-mysql/README.md` | Endpoints, auth, config, middleware |
+
+## CONVENTIONS
+- Keep examples runnable as standalone modules (`go.mod` local to each example).
+- Favor explicit composition and readable flow over framework internals.
+- Keep docs and commands in each example synchronized with behavior.
+
+## ANTI-PATTERNS
+- Do not couple examples to private internals from other example modules.
+- Do not add hidden setup steps that are missing from README/Makefile.
+- Do not hand-edit generated files in example subtrees (`sqlc`, swagger output).
+
+## COMMANDS
+```bash
+go test ./examples/hello-simple/...
+go test ./examples/hello-mysql/...
+```
+
+## NOTES
+- See `examples/hello-mysql/AGENTS.md` for generation and integration-test rules.

--- a/examples/hello-mysql/AGENTS.md
+++ b/examples/hello-mysql/AGENTS.md
@@ -1,0 +1,56 @@
+# HELLO-MYSQL KNOWLEDGE BASE
+
+## OVERVIEW
+`hello-mysql` is a full consuming app module: HTTP API, MySQL, migrations, sqlc, swagger.
+
+## STRUCTURE
+```text
+examples/hello-mysql/
+|- cmd/            # api, migrate, seed entrypoints
+|- internal/
+|  |- modules/     # app, auth, users, database, audit
+|  |- platform/    # mysql, config, logging adapters
+|  |- middleware/  # CORS/rate-limit/timing
+|  `- sqlc/        # generated queries/models (read-only)
+|- migrations/     # SQL migrations
+|- sql/            # source queries + sqlc config
+`- docs/           # swagger output (generated)
+```
+
+## WHERE TO LOOK
+| Task | Location | Notes |
+|---|---|---|
+| API startup and shutdown | `cmd/api/main.go` | Server wiring + graceful shutdown |
+| DB migration CLI | `cmd/migrate/main.go` | Use for schema changes |
+| Seed CLI | `cmd/seed/main.go` | Local data bootstrap |
+| Domain wiring | `internal/modules` | Module boundaries and exports |
+| MySQL connection lifecycle | `internal/platform/mysql` | `*sql.DB` setup and cleanup |
+| RFC7807 errors | `internal/httpapi` + module `problem.go` files | Uniform error payloads |
+
+## CONVENTIONS
+- Keep routes grouped under `/api/v1`; keep `/docs` and `/swagger` outside API middleware group.
+- Maintain RFC7807 response shape for validation and domain errors.
+- Regenerate artifacts when source changes (`sql/queries.sql`, OpenAPI comments).
+
+## ANTI-PATTERNS
+- Do not edit generated files directly:
+  - `internal/sqlc/*.go`
+  - `docs/docs.go`
+  - `docs/swagger.json`
+  - `docs/swagger.yaml`
+- Do not bypass module boundaries by cross-package direct state access.
+- Do not hardcode production secrets in tests or sample config.
+
+## COMMANDS
+```bash
+make run
+make test
+make migrate
+make seed
+make sqlc
+make swagger
+```
+
+## NOTES
+- Integration and smoke tests may require Docker/testcontainers availability.
+- Module-specific conventions are in `examples/hello-mysql/internal/modules/AGENTS.md`.

--- a/examples/hello-mysql/internal/modules/AGENTS.md
+++ b/examples/hello-mysql/internal/modules/AGENTS.md
@@ -1,0 +1,45 @@
+# HELLO-MYSQL MODULES KNOWLEDGE BASE
+
+## OVERVIEW
+Domain module layer for the sample app (`app`, `auth`, `users`, `database`, `audit`). Keep boundaries explicit via imports/exports.
+
+## STRUCTURE
+```text
+internal/modules/
+|- app/       # Top-level app composition and health routes
+|- auth/      # Login, claims, middleware, token config
+|- users/     # CRUD endpoints, service, repo integration
+|- database/  # DB provider module + cleanup hooks
+`- audit/     # Audit service module
+```
+
+## WHERE TO LOOK
+| Task | Location | Notes |
+|---|---|---|
+| Root composition order | `app/module.go` | Imports all required modules |
+| Token/auth behavior | `auth/{module,token,middleware,handler}.go` | Protected route contracts |
+| Users domain flow | `users/{module,controller,service,repo_mysql}.go` | Request -> service -> persistence |
+| DB lifecycle hooks | `database/{module,cleanup}.go` | Close pools using provider cleanup |
+| Audit integration | `audit/{module,service}.go` | Consumes exports, no hidden coupling |
+
+## CONVENTIONS
+- Module names and provider tokens stay stable and explicit.
+- `Definition()` methods remain deterministic and side-effect free.
+- Services return explicit errors; controllers map to Problem Details.
+- Keep tests adjacent to module code; preserve table/subtest style.
+
+## ANTI-PATTERNS
+- Do not resolve dependencies and ignore `err` from `r.Get()`.
+- Do not add cross-module direct struct wiring that bypasses exports.
+- Do not mix transport validation logic deep inside repositories.
+- Do not mutate module definition fields at runtime.
+
+## COMMANDS
+```bash
+go test ./examples/hello-mysql/internal/modules/...
+go test ./examples/hello-mysql/internal/modules/auth/...
+go test ./examples/hello-mysql/internal/modules/users/...
+```
+
+## NOTES
+- Inherit root and `examples/hello-mysql` guidance; this file only adds module-layer rules.

--- a/modkit/AGENTS.md
+++ b/modkit/AGENTS.md
@@ -1,0 +1,45 @@
+# MODKIT PACKAGE KNOWLEDGE BASE
+
+## OVERVIEW
+Core framework packages: metadata (`module`), runtime (`kernel`), HTTP adapter (`http`), logging (`logging`).
+
+## STRUCTURE
+```text
+modkit/
+|- module/    # Public metadata and validation
+|- kernel/    # Graph + visibility + container + bootstrap
+|- http/      # Router/server/middleware adapter around chi
+`- logging/   # Logger contract + adapters
+```
+
+## WHERE TO LOOK
+| Task | Location | Notes |
+|---|---|---|
+| Define/validate module metadata | `modkit/module/module.go` | Deterministic definition contract |
+| Provider/controller token contracts | `modkit/module/{provider,controller,token}.go` | Exported API entry points |
+| Build graph and visibility | `modkit/kernel/{graph,visibility}.go` | Import traversal and export checks |
+| Runtime dependency resolution | `modkit/kernel/container.go` | Lazy singleton provider creation |
+| Bootstrap flow | `modkit/kernel/bootstrap.go` | App creation + controller instantiation |
+| Route registration contract | `modkit/http/{router,server,register}.go` | Explicit registration only |
+| Logging adapters | `modkit/logging/{logger,slog,nop}.go` | Keep logger contract minimal |
+
+## CONVENTIONS
+- Prefer explicit behavior over metaprogramming; keep API surfaces clear.
+- Keep exported APIs minimal; new exports require strong justification.
+- Error values are typed/sentinel where useful; wrap with `%w`.
+- Keep tests adjacent to implementation.
+
+## ANTI-PATTERNS
+- Do not add reflection/decorator-driven dependency injection.
+- Do not hide dependency lookup failures; always return contextual errors.
+- Do not introduce framework-global mutable state.
+- Do not weaken visibility checks for convenience.
+
+## PACKAGE COMMANDS
+```bash
+go test ./modkit/...
+go test -race ./modkit/...
+```
+
+## NOTES
+- Root policies still apply; this file adds package-local guidance only.


### PR DESCRIPTION
## Summary
- Replace root `AGENTS.md` with a structured project knowledge base tailored to current repo architecture.
- Add scoped AGENTS files for `modkit`, `examples`, `examples/hello-mysql`, and `examples/hello-mysql/internal/modules` to keep local conventions close to code.
- Keep guidance concise and non-duplicative, including generated-file constraints and module-specific workflow notes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized project knowledge base with streamlined structure and consolidated guidance across directories.
  * Added new documentation guides for examples, module layers, and core packages to improve navigation and conventions reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->